### PR TITLE
Ruby 2.6+, Rubocop 1.4+, add tests for Ruby 2.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,24 +13,18 @@ ruby_env: &ruby_env
     - image: circleci/ruby:<<parameters.ruby-version>>
 
 executors:
-  ruby_2_4:
-    <<: *ruby_env
-    parameters:
-      ruby-version:
-        type: string
-        default: "2.4.6"
-  ruby_2_5:
-    <<: *ruby_env
-    parameters:
-      ruby-version:
-        type: string
-        default: "2.5.5"
   ruby_2_6:
     <<: *ruby_env
     parameters:
       ruby-version:
         type: string
         default: "2.6.3"
+  ruby_2_7:
+    <<: *ruby_env
+    parameters:
+      ruby-version:
+        type: string
+        default: "2.7.1"
 
 commands:
   pre-setup:
@@ -86,7 +80,7 @@ jobs:
     parameters:
       e:
         type: executor
-        default: "ruby_2_4"
+        default: "ruby_2_6"
     steps:
       - pre-setup
       - bundle-install
@@ -96,7 +90,7 @@ jobs:
     parameters:
       e:
         type: executor
-        default: "ruby_2_4"
+        default: "ruby_2_6"
     steps:
       - pre-setup
       - bundle-install
@@ -106,7 +100,7 @@ jobs:
     parameters:
       e:
         type: executor
-        default: "ruby_2_4"
+        default: "ruby_2_6"
     steps:
       - pre-setup
       - bundle-install
@@ -114,25 +108,6 @@ jobs:
 
 workflows:
   version: 2
-  ruby_2_4:
-    jobs:
-      - bundle-audit:
-          name: "ruby-2_4-bundle_audit"
-      - rubocop:
-          name: "ruby-2_4-rubocop"
-      - rspec-unit:
-          name: "ruby-2_4-rspec"
-  ruby_2_5:
-    jobs:
-      - bundle-audit:
-          name: "ruby-2_5-bundle_audit"
-          e: "ruby_2_5"
-      - rubocop:
-          name: "ruby-2_5-rubocop"
-          e: "ruby_2_5"
-      - rspec-unit:
-          name: "ruby-2_5-rspec"
-          e: "ruby_2_5"
   ruby_2_6:
     jobs:
       - bundle-audit:
@@ -144,3 +119,14 @@ workflows:
       - rspec-unit:
           name: "ruby-2_6-rspec"
           e: "ruby_2_6"
+  ruby_2_7:
+    jobs:
+      - bundle-audit:
+          name: "ruby-2_7-bundle_audit"
+          e: "ruby_2_7"
+      - rubocop:
+          name: "ruby-2_7-rubocop"
+          e: "ruby_2_7"
+      - rspec-unit:
+          name: "ruby-2_7-rspec"
+          e: "ruby_2_7"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,20 +1,56 @@
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.6
+  NewCops: enable
   Exclude:
-    - spec/**/*
     - .bundle/**/*
     - bin/**/*
     - vendor/**/*
     - tmp/**/*
     - log/**/*
-    - Rakefile
-    - gruf-commander.gemspec
+    - spec/support/**/*
+require:
+  - rubocop-rspec
+  - rubocop-performance
+  - rubocop-thread_safety
 
 Metrics/AbcSize:
   Max: 30
 
-Metrics/LineLength:
+Layout/LineLength:
   Enabled: false
 
 Metrics/MethodLength:
   Max: 20
+
+Metrics/BlockLength:
+  Exclude:
+    - spec/**/*
+
+####################################################################################################
+# RSpec Configurations
+####################################################################################################
+
+RSpec/MessageSpies:
+  EnforcedStyle: receive
+
+RSpec/MultipleExpectations:
+  Max: 15
+
+RSpec/NamedSubject:
+  Enabled: false
+
+RSpec/NestedGroups:
+  Enabled: false
+
+RSpec/MultipleMemoizedHelpers:
+  Enabled: false
+
+RSpec/ExampleLength:
+  Max: 50
+
+RSpec/AnyInstance:
+  Enabled: false
+
+# This does not work with RPC messages
+RSpec/VerifiedDoubles:
+  Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@ Changelog for the gruf-commander gem. This includes internal history before the 
 
 ### Pending release
 
+### 1.1.0
+
+- Bump minimum required Ruby version to 2.6
+- Bump Rubocop to 1.4
+- Add tests for Ruby 2.7
+
 ### 1.0.0
 
 - Add frozen_string_literal: true to all files

--- a/Gemfile
+++ b/Gemfile
@@ -17,23 +17,4 @@
 #
 source 'https://rubygems.org'
 
-git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
-
 gemspec
-
-gem 'gruf', '~> 2.4'
-
-group :development, :test do
-  gem 'factory_bot',    '~> 5.0'
-  gem 'ffaker',         '~> 2.8'
-  gem 'pry-byebug',     '~> 3.5'
-  gem 'rubocop',        '~> 0.68'
-end
-
-group :test do
-  gem 'bundler-audit',         '~> 0.6'
-  gem 'null-logger',           '~> 0.1'
-  gem 'rspec',                 '~> 3.8'
-  gem 'rspec_junit_formatter', '~> 0.4.1'
-  gem 'simplecov',             '~> 0.15', require: false
-end

--- a/Rakefile
+++ b/Rakefile
@@ -16,5 +16,7 @@
 # OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
+
 RSpec::Core::RakeTask.new(:spec)
+
 task default: :spec

--- a/gruf-commander.gemspec
+++ b/gruf-commander.gemspec
@@ -15,7 +15,7 @@
 # COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 # OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'gruf/commander/version'
 
@@ -32,9 +32,22 @@ Gem::Specification.new do |spec|
   spec.files         = Dir['README.md', 'CHANGELOG.md', 'CODE_OF_CONDUCT.md', 'lib/**/*', 'gruf-commander.gemspec']
   spec.require_paths = ['lib']
 
+  spec.required_ruby_version = '~> 2.6'
+
   spec.add_development_dependency 'bundler', '>= 1.16'
-  spec.add_development_dependency 'rake', '>= 10.0'
+  spec.add_development_dependency 'bundler-audit', '>= 0.6'
+  spec.add_development_dependency 'factory_bot', '>= 5.0'
+  spec.add_development_dependency 'ffaker', '>= 2.8'
+  spec.add_development_dependency 'pry', '>= 0.12'
+  spec.add_development_dependency 'pry-byebug', '>= 3.9'
   spec.add_development_dependency 'rspec', '>= 3.8'
+  spec.add_development_dependency 'rspec_junit_formatter', '>= 0.4'
+  spec.add_development_dependency 'rubocop', '>= 1.4'
+  spec.add_development_dependency 'rubocop-performance', '>= 0.0.1'
+  spec.add_development_dependency 'rubocop-rspec', '>= 2.0'
+  spec.add_development_dependency 'rubocop-thread_safety', '>= 0.3'
+  spec.add_development_dependency 'simplecov', '>= 0.15'
 
   spec.add_runtime_dependency 'activemodel', '> 4'
+  spec.add_runtime_dependency 'gruf', '>= 2.4'
 end

--- a/script/test
+++ b/script/test
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+echo "Running bundle install..."
+bundle install
+
+echo "Running bundler-audit..."
+bundle exec bundle-audit update
+bundle exec bundle-audit check
+
+echo "Running rubocop..."
+bundle exec rubocop -P -c ./.rubocop.yml
+
+echo "Running rspec..."
+bundle exec rspec
+
+echo "Tests finished."

--- a/spec/gruf/commander/command_spec.rb
+++ b/spec/gruf/commander/command_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2018-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
@@ -20,7 +22,8 @@ describe Gruf::Commander::Command do
 
   describe '.call' do
     subject { command.call(nil) }
-    it 'should raise a NotImplementedError' do
+
+    it 'raises a NotImplementedError' do
       expect { subject }.to raise_error(NotImplementedError)
     end
   end

--- a/spec/gruf/commander/request_spec.rb
+++ b/spec/gruf/commander/request_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2018-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
@@ -19,20 +21,20 @@ describe Gruf::Commander::Request do
   let(:request_params) { { width: 5, height: 10 } }
   let(:request) { CreateBoxRequest.new(request_params) }
 
-  describe '.submit!' do
+  describe '#submit!' do
     subject { request.submit! }
 
-    context 'if the request is valid' do
-      it 'should run call on the command' do
+    context 'when the request is valid' do
+      it 'runs call on the command' do
         expect(request.command).to receive(:call).with(request).once
-        expect { subject }.to_not raise_error
+        expect { subject }.not_to raise_error
       end
     end
 
-    context 'if the request is invalid' do
+    context 'when the request is invalid' do
       let(:request_params) { { width: 0, height: 7 } }
 
-      it 'should raise an InvalidRequest exception' do
+      it 'raises an InvalidRequest exception' do
         expect { subject }.to raise_error(Gruf::Commander::InvalidRequest)
       end
     end

--- a/spec/gruf/commander/request_validation_interceptor_spec.rb
+++ b/spec/gruf/commander/request_validation_interceptor_spec.rb
@@ -1,5 +1,6 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2018-present, BigCommerce Pty. Ltd. All rights reserved
-#
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
 # documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
 # rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
@@ -16,8 +17,6 @@
 require 'spec_helper'
 
 describe Gruf::Commander::RequestValidationInterceptor do
-  let(:controller_request) { double(:controller_request) }
-
   let(:controller_request) do
     double(
       :controller_request,
@@ -31,22 +30,21 @@ describe Gruf::Commander::RequestValidationInterceptor do
   let(:error) { Gruf::Error.new }
   let(:options) { {} }
   let(:interceptor) { described_class.new(controller_request, error, options) }
-
   let(:request) { CreateBoxRequest.new(width: 5, height: 10) }
 
-  describe '.call' do
+  describe '#call' do
     subject { interceptor.call { request.submit! } }
 
     context 'when the call succeeds' do
-      it 'should noop' do
-        expect { subject }.to_not raise_error
+      it 'no-ops' do
+        expect { subject }.not_to raise_error
       end
     end
 
     context 'when the call raises an InvalidRequest' do
       let(:request) { CreateBoxRequest.new(width: 0, height: 10) }
 
-      it 'should fail and set the appropriate field errors' do
+      it 'fails and set the appropriate field errors' do
         expect { subject }.to raise_error(GRPC::InvalidArgument) do |e|
           expect(e.details).to eq 'Invalid request'
           expect(e.code).to eq 3
@@ -56,7 +54,7 @@ describe Gruf::Commander::RequestValidationInterceptor do
           expect(err['app_code']).to eq 'invalid_request'
           expect(err['message']).to eq 'Invalid request'
 
-          expect(err['field_errors']).to_not be_empty
+          expect(err['field_errors']).not_to be_empty
           fe = err['field_errors'][0]
           expect(fe['field_name']).to eq 'width'
           expect(fe['error_code']).to eq 'invalid_width'

--- a/spec/gruf/commander_spec.rb
+++ b/spec/gruf/commander_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2018-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
@@ -17,6 +19,6 @@ require 'spec_helper'
 
 describe Gruf::Commander do
   it 'has a version number' do
-    expect(Gruf::Commander::VERSION).not_to be nil
+    expect(Gruf::Commander::VERSION).not_to be_nil
   end
 end

--- a/spec/simplecov_helper.rb
+++ b/spec/simplecov_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2018-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2018-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
@@ -13,27 +15,19 @@
 # COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 # OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
-$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+$LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 require_relative 'simplecov_helper'
 require 'gruf'
 require 'gruf/commander'
 require 'ffaker'
 require 'pry'
 
-Dir["#{File.join(File.dirname(__FILE__), 'support')}/**/*.rb"].each { |f| require f }
+Dir["#{File.join(__dir__, 'support')}/**/*.rb"].sort.each { |f| require f }
 
 RSpec.configure do |config|
-  config.alias_example_to :fit, focus: true
-  config.filter_run focus: true
-  config.filter_run_excluding broken: true
-  config.run_all_when_everything_filtered = true
-  config.expose_current_running_example_as :example
   config.mock_with :rspec do |mocks|
     mocks.allow_message_expectations_on_nil = true
   end
   config.color = true
-
   config.include Gruf::Commander::SpecHelpers
 end
-
-Thread.abort_on_exception = true

--- a/spec/support/grpc.rb
+++ b/spec/support/grpc.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2018-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated

--- a/spec/support/test_objects.rb
+++ b/spec/support/test_objects.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2018-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated


### PR DESCRIPTION
- Bump minimum required Ruby version to 2.6
- Bump Rubocop to 1.4
- Add tests for Ruby 2.7

----

@bigcommerce/oss-maintainers @bigcommerce/platform-engineering @bigcommerce/ruby 