### PR TITLE
Fix NameError with InvalidRequest object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Changelog for the gruf-commander gem. This includes internal history before the 
 
 ### Pending release
 
+- Fix NameError with InvalidRequest object
+
 ### 1.3.0
 
 - Add support for Ruby 3.2, 3.3, 3.4

--- a/lib/gruf/commander/invalid_request.rb
+++ b/lib/gruf/commander/invalid_request.rb
@@ -18,32 +18,19 @@
 module Gruf
   module Commander
     ##
-    # Base request class
+    # Used when submitting requests from commands; utilize to issue a validation exception on a request
     #
-    class Request
-      include ActiveModel::Validations
-
-      # @var [Command] command
-      attr_reader :command
+    class InvalidRequest < StandardError
+      attr_reader :request
 
       ##
-      # @param [Command] command
+      # @param [Request] request
+      # @param [String] message
       #
-      def initialize(command:)
-        @command = command
+      def initialize(request, message = '')
+        @request = request
+        super(message)
       end
-
-      ##
-      # Validate and submit the request
-      #
-      # @raise [InvalidRequest] if the request is invalid
-      # rubocop:disable Style/RaiseArgs
-      def submit!
-        raise InvalidRequest.new(self) unless valid?
-
-        command.call(self)
-      end
-      # rubocop:enable Style/RaiseArgs
     end
   end
 end

--- a/spec/gruf/commander/invalid_request_spec.rb
+++ b/spec/gruf/commander/invalid_request_spec.rb
@@ -15,35 +15,22 @@
 # COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 # OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
-module Gruf
-  module Commander
-    ##
-    # Base request class
-    #
-    class Request
-      include ActiveModel::Validations
+require 'spec_helper'
 
-      # @var [Command] command
-      attr_reader :command
+describe Gruf::Commander::InvalidRequest do
+  let(:req) { instance_double(Gruf::Controllers::Request, method: 'TestMethod', service: 'TestService') }
+  let(:error) { described_class.new(req, 'Invalid request') }
 
-      ##
-      # @param [Command] command
-      #
-      def initialize(command:)
-        @command = command
-      end
+  describe '#message' do
+    it 'returns the correct message' do
+      expect(error.message).to eq 'Invalid request'
+    end
+  end
 
-      ##
-      # Validate and submit the request
-      #
-      # @raise [InvalidRequest] if the request is invalid
-      # rubocop:disable Style/RaiseArgs
-      def submit!
-        raise InvalidRequest.new(self) unless valid?
-
-        command.call(self)
-      end
-      # rubocop:enable Style/RaiseArgs
+  describe '#inspect' do
+    it 'returns a string representation of the error' do
+      expect(error.inspect).to include('Gruf::Commander::InvalidRequest')
+      expect(error.inspect).to include('Invalid request')
     end
   end
 end


### PR DESCRIPTION
## What? Why?

Fixes `NameError: uninitialized constant Gruf::Commander::InvalidRequest` due to switch to Zeitwerk and the file having two classes in it (as opposed to separate files for separate classes).

## How was it tested?

Added unit tests for rspec for this class to ensure autoloading worked as expected.