### PR TITLE
Fix issue with autoloading in eager loaded Rails envs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Changelog for the gruf-commander gem. This includes internal history before the 
 
 ### Pending release
 
+- Fix autoloading issue in certain Rails environments
+
 ### 1.3.1
 
 - Fix NameError with InvalidRequest object

--- a/lib/autoloader.rb
+++ b/lib/autoloader.rb
@@ -17,6 +17,11 @@
 
 # use Zeitwerk to lazily autoload all the files in the lib directory
 require 'zeitwerk'
+lib_dir = __dir__.to_s
 loader = Zeitwerk::Loader.for_gem(warn_on_extra_files: false)
-loader.ignore(File.join(__dir__.to_s, 'gruf-commander.rb'))
+loader.inflector.inflect('version' => 'VERSION')
+loader.ignore(
+  File.join(lib_dir, 'gruf-commander.rb'),
+  File.join(lib_dir, 'autoloader.rb')
+)
 loader.setup


### PR DESCRIPTION
## What/Why?

Fixes an issue where eager loading and rails' use of zeitwerk cause a constant not found issue, due to some files not being ignored by zeitwerk's usage in this gem.

## Rollout/Rollback

Revert.

## Testing

Tested on a Rails app. Works as expected.